### PR TITLE
Feature/gen otp

### DIFF
--- a/api/DB.py
+++ b/api/DB.py
@@ -30,3 +30,7 @@ def loginAuth(id,pw):
             return False
     else:
         return False
+    
+#기기추가
+def addDevice(data):
+    return "Message"

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,7 +9,7 @@ ENV DB_NAME rdms
 ENV DB_USER root
 ENV DB_PASSWORD mysql_root_password
 
-RUN pip install flask
+RUN pip install flask[async]
 RUN pip install Flask-Cors
 RUN pip install python-dotenv
 RUN pip install pymysql

--- a/api/OTP.py
+++ b/api/OTP.py
@@ -1,0 +1,75 @@
+from random import randint
+import asyncio
+import time
+
+#otp 작업 저장해둘 딕셔너리, key = otp, value = info
+otp_list = {}
+
+#OTP생성
+def generate(type, data):
+    while True:
+        otp = str(randint(0,9999)).zfill(4)
+        if otp not in otp_list:
+            break
+    otp_info = {"expires":time.time()+180,"type":type,"data":data,"execute":False, "valid":False}
+    otp_list[otp] = otp_info
+    return otp
+
+#OTP 인증여부 확인
+async def valid_wait(otp):
+    otp_info = otp_list[otp]
+    while True:
+        if time.time()> otp_info["expires"]:
+            return False
+        if otp_info["valid"]:
+            return True
+        await asyncio.sleep(0.1)
+        
+
+#OTP 실행
+async def execute(otp):
+    if otp in otp_list:
+        otp_info = otp_list[otp]
+        if otp_info["execute"] == False:
+            if otp_info["expires"] >= time.time():
+                otp_info["execute"] = True
+                if await valid_wait(otp):
+                    del(otp_list[otp])
+                    return True
+                else:
+                    del(otp_list[otp])
+                    return False
+                
+            else:
+                del(otp_list[otp])
+                return False
+        else:
+            return False
+    else:
+        return False
+
+#OTP 인증
+def valid(otp):
+    if otp in otp_list:
+        otp_info = otp_list[otp]
+        if otp_info["expires"] >= time.time():
+            if otp_info["execute"]:
+                #작업수행
+                res = "작업결과"
+                otp_info["valid"]=True
+                return res
+            else:
+                return False
+        else:
+            del(otp_list[otp])
+            return False
+    else:
+        return False
+
+#OTP 만료설정
+def expire(otp):
+    if otp in otp_list:
+        otp_list[otp]["expires"] = 0
+        return True
+    else:
+        return False

--- a/api/app.py
+++ b/api/app.py
@@ -2,6 +2,8 @@ from flask import Flask, request, abort, session
 from flask_cors import CORS
 import DB
 import os
+import random
+import time
 
 #Flask 앱 생성 및 설정
 app = Flask(__name__)
@@ -13,6 +15,9 @@ CORS(app, resources={r'*': {'origins': '*'}})
 #배포 주소 및 포트
 host_addr = "0.0.0.0"
 host_port = 5000
+
+#otp 작업 저장해둘 딕셔너리, key = otp, value = info
+otp_list = {}
 
 #응답 형식 반환
 def response_format(msg,data={}):
@@ -44,11 +49,30 @@ def login():
         abort(400)
 
 #로그아웃 기능
-@app.route("/api/auth/logout",methods=['GET'])
+@app.route("/api/auth/logout",methods=['POST'])
 def logout(): 
     if "username" in session: 
         session.clear()
         return response_format("Success")
+    else:
+        return abort(401)
+
+@app.route("/api/auth/otp/gen",methods=['GET'])
+def get_otp(): 
+    if "username" in session: 
+        body = request.get_json()
+        if "type" in body and "data" in body:
+            type = body["type"]
+            data = body["data"]
+            while True:
+                otp = random.randint(0,9999)
+                if otp not in otp_list:
+                    break
+            otp_info = {"expires":time.time()+180,"type":type,"data":data}
+            otp_list[otp] = otp_info
+            return response_format("Success",{"otp":otp})
+        else:
+            return abort(400)
     else:
         return abort(401)
 


### PR DESCRIPTION
## Motivation
- `gen`, `execute`, `expire`의 경우 프론트에서 요청하도록 구현 (세션 인증 필요)
- `valid`의 경우 디바이스 컨트롤러에서 요청하도록 구현
- OTP 인증 과정은 다음과 같음
 `gen`요청 -> `gen` 응답 -> `execute`요청 -> `valid`요청 -> `execute`응답, `valid` 응답
- `expire`요청을 하면 진행 단계에 관련 없이 해당 otp는 만료됨
- `execute`요청의 경우 `valid`요청이 들어오고 작업이 끝날 때 까지 대기한 후 응답
- `valid`요청은 `execute`가 선행되지 않을 경우 Fail을 응답
- 인증 과정에서 otp가 만료될 시 Fail을 응답
- OTP의 유효기간은 3분으로 설정함

## key Changes
- `auth/otp/gen` 추가
- `auth/otp/valid` 추가
- `auth/otp/execute` 추가
- `auth/otp/expire` 추가

## To Reviewers
Self merge 예정