### PR TITLE
Feature/login data request

### DIFF
--- a/api/DB.py
+++ b/api/DB.py
@@ -18,18 +18,37 @@ cursor = db.cursor()
 print("test")
 
 #로그인시 id와 pw 검사
-def loginAuth(id,pw):
+def loginAuth(username, password):
     sql = f"SELECT password FROM rdms_accounts WHERE username=%s"
-    cursor.execute(sql,(id,))
+    cursor.execute(sql,(username,))
     result = cursor.fetchall()
     if len(result)==1:
         #비밀번호 비교
-        if checkpw(pw.encode('utf-8'),result[0][0].encode('utf-8')):
+        if checkpw(password.encode('utf-8'),result[0][0].encode('utf-8')):
             return True
         else:
             return False
     else:
         return False
+    
+def getUser(username):
+    sql = f"SELECT id,name,username,root_permission,preference FROM rdms_accounts WHERE username=%s"
+    cursor.execute(sql,(username,))
+    result = cursor.fetchall()
+    if len(result)==1:
+        result = result[0]
+        data = {
+            "id":result[0],
+            "name":result[1],
+            "username":result[2],
+            "root_permission":result[3],
+            "perference":result[4]
+            }
+        return data
+    else:
+        return None
+
+    
     
 #기기추가
 def addDevice(data):

--- a/api/app.py
+++ b/api/app.py
@@ -39,7 +39,8 @@ def login():
 
         if DB.loginAuth(username, password):
             session["username"] = username
-            return response_format("Success")
+            data = DB.getUser(username)
+            return response_format("Success",data)
         else:
             return response_format("Fail")
     else:

--- a/api/app.py
+++ b/api/app.py
@@ -25,7 +25,8 @@ def response_format(msg,data={}):
 @app.route("/api/auth/valid",methods=['GET'])
 def valid(): 
     if "username" in session: 
-        return response_format("Success")
+        data = DB.getUser(session["username"])
+        return response_format("Success",data)
     else:
         return response_format("Fail")
 

--- a/database/scripts/create_table.sql
+++ b/database/scripts/create_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE rdms_accounts (
 `username` VARCHAR(256) NOT NULL,
 `password` VARCHAR(256) NOT NULL,
 `root_permission` BOOLEAN NOT NULL DEFAULT FALSE,
-`perference` BLOB,
+`preference` BLOB,
 PRIMARY KEY (id)
 )ENGINE=InnoDB CHARSET=utf8mb4;
 


### PR DESCRIPTION
## Motivation
- 프론트 엔드에서 name을 표시하고, 추후 개인설정을 불러오기 위해 auth/login과 auth/valid응답에 유저정보를 포함시킴
- 비밀번호를 제외한 id, name, username, root_permission, preference가 표함됨
- 이후에도 재활용 할 수 있도록 DB.py 에 getUser라는 함수로 구현함
<br>

## Key Changes
- rdms_accounts 테이블 생성시 컬럼명에 있던 오타 수정
- loginAuth의 매개변수명을 명확하게 함
- auth/login과 auth/valid 요청에 응답으로 유저데이터(id, name, username, root_permission,preference)를 포함함

<br>

## To Reviewers
Self Merge 예정
